### PR TITLE
Replace errx/warnx for building in Windows MinGW64

### DIFF
--- a/fonts/afm2add.c
+++ b/fonts/afm2add.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <err.h>
 
 #include "parseafm.h"
 #include "fonts.h"
@@ -19,50 +18,58 @@ int main(int argc, char **argv)
     FILE *afm, *tbl;
 
     if (argc != 2) {
-        errx(EXIT_FAILURE, "No .afm file specified");
-    }
+				fprintf(stderr, "No .afm file specified\n");
+				return EXIT_FAILURE;
+			}
 
     if ((afm = fopen(argv[1], "r")) == NULL) {
-        err(EXIT_FAILURE, "Failed to open specified file");
-    }
+				fprintf(stderr, "Failed to open specified file\n");
+				return EXIT_FAILURE;
+			}
 
     // This describes the font file we're translating.
     if (parseFile(afm, &fi, P_GMP) != ok) {
-        warnx("The afm file was not *fully* parsed (probably still okay).");
+        fprintf(stderr, "The afm file was not *fully* parsed (probably still okay).");
     }
 
     // This contains the pslgyph <=> wordperfect mappings.
     if (initialize_charmap("charmap.ini") != true) {
-        err(EXIT_FAILURE, "Failed to parse the charmap ini file");
-    }
+				fprintf(stderr, "Failed to parse the charmap ini file\n");
+				return EXIT_FAILURE;
+			}
 
     // Make sure this makes sense.
     if (fi->gfi->fontName == NULL) {
-        err(EXIT_FAILURE, "The font does not have a name");
-    }
+				fprintf(stderr, "The font does not have a name\n");
+				return EXIT_FAILURE;
+			}
 
     // Only proportional fonts use kerning and spacing.
     if (fi->gfi->isFixedPitch == false)  {
         sprintf(filename, "%.8s.KRN", fi->gfi->fontName);
 
         if ((tbl = fopen(filename, "w")) == NULL) {
-            err(EXIT_FAILURE, "failed to create kerning table %s", filename);
-        }
+				fprintf(stderr, "Failed to create kerning table\n");
+				// message above included %s, but this generates a warning that I can't fix
+				return EXIT_FAILURE;
+			}
 
         if (generate_kerning_table(fi,
                                    tbl,
                                    fi->gfi->fontName,
                                    true,
                                    12) != true) {
-            err(EXIT_FAILURE, "failed to generate kerning table");
-        }
+				fprintf(stderr, "failed to generate kerning table\n");
+				return EXIT_FAILURE;
+			}
 
         fclose(tbl);
         sprintf(filename, "%.8s.SPC", fi->gfi->fontName);
 
         if ((tbl = fopen(filename, "w")) == NULL) {
-            err(EXIT_FAILURE, "failed to create spacing table %s", filename);
-        }
+				fprintf(stderr, "Failure to create spacing table\n");
+				return EXIT_FAILURE;
+			}
 
         if (generate_spacing_table(fi,
                                    tbl,
@@ -70,8 +77,9 @@ int main(int argc, char **argv)
                                    NULL,
                                    true,
                                    12) != true) {
-            err(EXIT_FAILURE, "failed to generate spacing table");
-        }
+				fprintf(stderr, "Failed to generate spacing table\n");
+				return EXIT_FAILURE;
+			}
 
         fclose(tbl);
     }
@@ -79,31 +87,36 @@ int main(int argc, char **argv)
     sprintf(filename, "%.8s.TYP", fi->gfi->fontName);
 
     if ((tbl = fopen(filename, "w")) == NULL) {
-        err(EXIT_FAILURE, "failed to create typeface descriptor %s", filename);
-    }
+				fprintf(stderr, "failure not yet specified");
+				return EXIT_FAILURE;
+			}
 
     if (generate_typeface_table(fi, tbl, fi->gfi->fontName, true) != true) {
-        err(EXIT_FAILURE, "failed to generate typeface descriptor");
-    }
+				fprintf(stderr, "failure not yet specified");
+				return EXIT_FAILURE;
+			}
 
     fclose(tbl);
     sprintf(filename, "%.8s.MAP", fi->gfi->fontName);
 
     if ((tbl = fopen(filename, "w")) == NULL) {
-        err(EXIT_FAILURE, "failed to create character map %s", filename);
-    }
+				fprintf(stderr, "failure not yet specified");
+				return EXIT_FAILURE;
+			}
 
     if (generate_charmap_table(fi, tbl, fi->gfi->fontName, true) != true) {
-        err(EXIT_FAILURE, "failed to create character map");
-    }
+				fprintf(stderr, "Failed to create character map\n");
+				return EXIT_FAILURE;
+			}
 
     fclose(tbl);
 
     sprintf(filename, "%.8s.ADD", fi->gfi->fontName);
 
     if ((tbl = fopen(filename, "w")) == NULL) {
-        err(EXIT_FAILURE, "failed to create operations file %s", filename);
-    }
+				fprintf(stderr, "failed to create operations file %s\n", filename);
+				return EXIT_FAILURE;
+			}
 
     if (generate_operations_file("GhostScript",
                                  fi,
@@ -113,8 +126,9 @@ int main(int argc, char **argv)
                                  tbl,
                                  true,
                                  12) != true) {
-        err(EXIT_FAILURE, "failed to create operations file");
-    }
+				fprintf(stderr, "failed to create operations file\n");
+				return EXIT_FAILURE;
+			}
 
     fprintf(stderr, "Translation seems to have worked.\n");
 

--- a/fonts/charmap.c
+++ b/fonts/charmap.c
@@ -6,7 +6,6 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
-#include <err.h>
 
 #include "prefix.h"
 #include "charset.h"
@@ -62,7 +61,10 @@ static int charmapline(void *user, const char *section, const char *name, const 
     return 1;
 
 error:
-    errx(EXIT_FAILURE, "The charmap entry for %s in %s was not valid.", name, section);
+    {
+				fprintf(stderr,"The charmap entry for %s in %s was not valid.\n", name, section);
+				return EXIT_FAILURE;
+			}
     return 0;
 }
 

--- a/fonts/gseval.c
+++ b/fonts/gseval.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdarg.h>
-#include <err.h>
 #include <assert.h>
 #include <ghostscript/ierrors.h>
 #include <ghostscript/iapi.h>
@@ -47,15 +46,19 @@ void gs_init_interpreter()
 {
     char * gsargs[] = { "gseval", "-q" };
 
-    if (gsapi_new_instance(&minst, NULL) < 0)
-        errx(EXIT_FAILURE, "gsapi_new_instance() failed");
+    if (gsapi_new_instance(&minst, NULL) < 0){
+				fprintf(stderr, "gsapi_new_instance() failed\m");
+				return EXIT_FAILURE;
+			}
 
     gsapi_set_arg_encoding(minst, GS_ARG_ENCODING_UTF8);
 
     gsapi_set_stdio(minst, gsdll_stdin, gsdll_stdout, gsdll_stderr);
 
-    if (gsapi_init_with_args(minst, countof(gsargs), gsargs) != 0)
-        errx(EXIT_FAILURE, "gsapi_init_with_args() failed");
+    if (gsapi_init_with_args(minst, countof(gsargs), gsargs) != 0){
+				fprintf(stderr, "gsapi_init_with_args() failed\n");
+				return EXIT_FAILURE;
+			}
     return;
 }
 
@@ -95,8 +98,9 @@ int32_t gs_eval_int(const char *str, ...)
     code = gsapi_run_string(minst, cmdbuf, 0, &result);
 
     if (code != 0) {
-        errx(EXIT_FAILURE, "gs error for `%s`", cmdbuf);
-    }
+				fprintf(stderr,"gs error for `%s`\n", cmdbuf));
+				return EXIT_FAILURE;
+			}
 
     gsapi_run_string(minst, "flush", 0, &result);
 
@@ -123,8 +127,9 @@ char * gs_eval_str(const char *str, ...)
     code = gsapi_run_string(minst, cmdbuf, 0, &result);
 
     if (code != 0) {
-        errx(EXIT_FAILURE, "gs error for `%s`", cmdbuf);
-    }
+				fprintf(stderr, "failure not yet specified");
+				return EXIT_FAILURE;
+			}
     gsapi_run_string(minst, "flush", 0, &result);
 
     assert(outbufsz);

--- a/fonts/kerning.c
+++ b/fonts/kerning.c
@@ -4,7 +4,6 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <err.h>
 
 #include "parseafm.h"
 #include "prefix.h"
@@ -171,8 +170,9 @@ bool generate_kerning_table(FontInfo *fi,
                                 glyphpair);
 
                 if (asciipair + glyphpair == 0) {
-                    errx(EXIT_FAILURE, "No glyphs in this font that I recognize, is it a graphic font???");
-                }
+										fprintf(stderr, "No glyphs in this font that I recognize, is it a graphic font???\n");
+										return EXIT_FAILURE;
+								}
 
                 putword(stream, asciipair);
                 putword(stream, glyphpair);


### PR DESCRIPTION
Amateurishly and incompetently replaces error/warming messages from err.h with stderr output. Not for real-world use, but perhaps makes revision easier.