### PR TITLE
Spec file fixes

### DIFF
--- a/wordperfect8.spec
+++ b/wordperfect8.spec
@@ -29,6 +29,7 @@ Provides:       bundled(libc) = 5.3.12-29
 #
 
 %define __strip /bin/true
+%global __provides_exclude_from ^/opt/wp80/lib
 
 %description
 WordPerfect is a word processing application for character terminals.
@@ -60,6 +61,7 @@ cp -r %{name}_i386/usr %{buildroot}
 - use a nicer source download URL
 - add missing BuildRequires and appropriate ExclusiveArch
 - strip redundant rpath
+- filter private libs from Provides:
 
 * Sat Aug 13 2022 Tavis Ormandy <taviso@gmail.com>
 - Renamed to match deb.

--- a/wordperfect8.spec
+++ b/wordperfect8.spec
@@ -11,6 +11,7 @@ Source2:        https://archive.download.redhat.com/pub/redhat/linux/5.2/en/os/i
 Source3:        https://archive.org/download/corel-wpunix-8/COREL_WPUNIX_1.iso
 ExclusiveArch:  i686
 BuildRequires:  bsdtar
+BuildRequires:  chrpath
 BuildRequires:  gcc
 BuildRequires:  gdb
 BuildRequires:  glibc-devel%{_isa}
@@ -24,7 +25,7 @@ Provides:       bundled(libc) = 5.3.12-29
 
 # Instructions:
 # $ spectool -g -R wordperfect8.spec
-# $ QA_RPATHS=$(( 0x0001|0x0010 )) rpmbuild --target i386 -bb wordperfect8.spec
+# $ setarch i686 rpmbuild -bb wordperfect8.spec
 #
 
 %define __strip /bin/true
@@ -42,6 +43,7 @@ cp %{SOURCE1} %{SOURCE2} %{SOURCE3} .
 
 %build
 make %{name}_i386
+chrpath -d %{name}_i386/opt/wp80/lib/ld-2.0.7.so
 
 %install
 cp -r %{name}_i386/opt %{buildroot}
@@ -57,6 +59,7 @@ cp -r %{name}_i386/usr %{buildroot}
 - fix typo in libc download URL
 - use a nicer source download URL
 - add missing BuildRequires and appropriate ExclusiveArch
+- strip redundant rpath
 
 * Sat Aug 13 2022 Tavis Ormandy <taviso@gmail.com>
 - Renamed to match deb.

--- a/wordperfect8.spec
+++ b/wordperfect8.spec
@@ -5,7 +5,7 @@ Summary:        WordPerfect for UNIX (TM) Character Terminals
 License:        Abandonware
 URL:            https://github.com/taviso/wpunix
 #Source0:       https://github.com/taviso/wpunix/archive/refs/heads/main.tar.gz
-Source0:        https://github.com/taviso/wpunix/archive/refs/tags/v%{version}.tar.gz
+Source0:        https://github.com/taviso/wpunix/archive/v%{version}/%{name}-%{version}.tar.gz
 Source1:        https://archive.download.redhat.com/pub/redhat/linux/5.2/en/os/i386/RedHat/RPMS/libc-5.3.12-27.i386.rpm
 Source2:        https://archive.download.redhat.com/pub/redhat/linux/5.2/en/os/i386/RedHat/RPMS/glibc-2.0.7-29.i386.rpm
 Source3:        https://archive.org/download/corel-wpunix-8/COREL_WPUNIX_1.iso
@@ -44,6 +44,7 @@ cp -r %{name}_i386/usr %{buildroot}
 * Tue Sep 27 2022 Dominik Mierzejewski <dominik@greysector.net> - 0.10-1
 - make version match actual tag in github release
 - fix typo in libc download URL
+- use a nicer source download URL
 
 * Sat Aug 13 2022 Tavis Ormandy <taviso@gmail.com>
 - Renamed to match deb.

--- a/wordperfect8.spec
+++ b/wordperfect8.spec
@@ -9,7 +9,18 @@ Source0:        https://github.com/taviso/wpunix/archive/v%{version}/%{name}-%{v
 Source1:        https://archive.download.redhat.com/pub/redhat/linux/5.2/en/os/i386/RedHat/RPMS/libc-5.3.12-27.i386.rpm
 Source2:        https://archive.download.redhat.com/pub/redhat/linux/5.2/en/os/i386/RedHat/RPMS/glibc-2.0.7-29.i386.rpm
 Source3:        https://archive.org/download/corel-wpunix-8/COREL_WPUNIX_1.iso
-Requires:       glibc(x86-32)
+ExclusiveArch:  i686
+BuildRequires:  bsdtar
+BuildRequires:  gcc
+BuildRequires:  gdb
+BuildRequires:  glibc-devel%{_isa}
+BuildRequires:  glibc-static%{_isa}
+BuildRequires:  make
+BuildRequires:  patchelf
+# just to avoid patching build script, not used for build
+BuildRequires:  wget
+Provides:       bundled(glibc) = 2.0.7-27
+Provides:       bundled(libc) = 5.3.12-29
 
 # Instructions:
 # $ spectool -g -R wordperfect8.spec
@@ -45,6 +56,7 @@ cp -r %{name}_i386/usr %{buildroot}
 - make version match actual tag in github release
 - fix typo in libc download URL
 - use a nicer source download URL
+- add missing BuildRequires and appropriate ExclusiveArch
 
 * Sat Aug 13 2022 Tavis Ormandy <taviso@gmail.com>
 - Renamed to match deb.

--- a/wordperfect8.spec
+++ b/wordperfect8.spec
@@ -1,5 +1,5 @@
 Name:           wordperfect8
-Version:        0.1
+Version:        0.10
 Release:        1%{?dist}
 Summary:        WordPerfect for UNIX (TM) Character Terminals
 License:        Abandonware
@@ -41,6 +41,9 @@ cp -r %{name}_i386/usr %{buildroot}
 /usr/bin/wp
 
 %changelog
+* Tue Sep 27 2022 Dominik Mierzejewski <dominik@greysector.net> - 0.10-1
+- make version match actual tag in github release
+
 * Sat Aug 13 2022 Tavis Ormandy <taviso@gmail.com>
 - Renamed to match deb.
 * Sat Aug 13 2022 Tavis Ormandy <taviso@gmail.com>

--- a/wordperfect8.spec
+++ b/wordperfect8.spec
@@ -6,7 +6,7 @@ License:        Abandonware
 URL:            https://github.com/taviso/wpunix
 #Source0:       https://github.com/taviso/wpunix/archive/refs/heads/main.tar.gz
 Source0:        https://github.com/taviso/wpunix/archive/refs/tags/v%{version}.tar.gz
-Source1:        https://archive.download.redhat.com/pub/redhat/linux/7.2/en/os/i386/RedHat/RPMS/libc-5.3.12-27.i386.rpm
+Source1:        https://archive.download.redhat.com/pub/redhat/linux/5.2/en/os/i386/RedHat/RPMS/libc-5.3.12-27.i386.rpm
 Source2:        https://archive.download.redhat.com/pub/redhat/linux/5.2/en/os/i386/RedHat/RPMS/glibc-2.0.7-29.i386.rpm
 Source3:        https://archive.org/download/corel-wpunix-8/COREL_WPUNIX_1.iso
 Requires:       glibc(x86-32)
@@ -43,6 +43,7 @@ cp -r %{name}_i386/usr %{buildroot}
 %changelog
 * Tue Sep 27 2022 Dominik Mierzejewski <dominik@greysector.net> - 0.10-1
 - make version match actual tag in github release
+- fix typo in libc download URL
 
 * Sat Aug 13 2022 Tavis Ormandy <taviso@gmail.com>
 - Renamed to match deb.

--- a/wordperfect8.spec
+++ b/wordperfect8.spec
@@ -51,8 +51,8 @@ cp -pr %{name}_i386/opt %{buildroot}
 cp -pr %{name}_i386/usr %{buildroot}
 
 %files
-/opt
-/usr/bin/wp
+/opt/wp80
+%{_bindir}/wp
 
 %changelog
 * Tue Sep 27 2022 Dominik Mierzejewski <dominik@greysector.net> - 0.10-1

--- a/wordperfect8.spec
+++ b/wordperfect8.spec
@@ -47,8 +47,8 @@ make %{name}_i386
 chrpath -d %{name}_i386/opt/wp80/lib/ld-2.0.7.so
 
 %install
-cp -r %{name}_i386/opt %{buildroot}
-cp -r %{name}_i386/usr %{buildroot}
+cp -pr %{name}_i386/opt %{buildroot}
+cp -pr %{name}_i386/usr %{buildroot}
 
 %files
 /opt
@@ -62,6 +62,7 @@ cp -r %{name}_i386/usr %{buildroot}
 - add missing BuildRequires and appropriate ExclusiveArch
 - strip redundant rpath
 - filter private libs from Provides:
+- preserve file timestamps
 
 * Sat Aug 13 2022 Tavis Ormandy <taviso@gmail.com>
 - Renamed to match deb.


### PR DESCRIPTION
This patch series makes it build on Fedora under mock (tested with `mock -r fedora-36-i386`) and makes the package closer to Fedora Packaging Guidelines.